### PR TITLE
add tc support and samples

### DIFF
--- a/samples/tc_ingress.zig
+++ b/samples/tc_ingress.zig
@@ -1,0 +1,86 @@
+const std = @import("std");
+const BPF = std.os.linux.BPF;
+const helpers = BPF.kern.helpers;
+
+const bpf = @import("bpf");
+const Tc = bpf.Tc;
+
+var ipv4 = bpf.Map.HashMap("ipv4", u32, u32, 1, 0).init();
+var ipv6 = bpf.Map.HashMap("ipv6", u32, u32, 1, 0).init();
+
+const EthHdr = extern struct {
+    dest: [6]u8,
+    src: [6]u8,
+    proto: u16,
+};
+
+const IcmpEchoHdr = extern struct {
+    typ: u8,
+    code: u8,
+    checksum: u16,
+    id: u16,
+    seq: u16,
+};
+
+const IPv6Hdr = extern struct {
+    flow: u32,
+    plen: u16,
+    nxt: u8,
+    hlim: u8,
+    src: [16]u8,
+    dst: [16]u8,
+};
+
+const IPv4Hdr = extern struct {
+    ver_ihl: u8,
+    tos: u8,
+    tot_len: u16,
+    id: u16,
+    frag_off: u16,
+    ttl: u8,
+    proto: u8,
+    check: u16,
+    src: u32,
+    dst: u32,
+};
+
+export fn tc_ingress(ctx: *Tc.SkBuff) linksection("tc") c_int {
+    const proto_ip4 = 0x0800;
+    const proto_ip6 = 0x86DD;
+
+    switch (ctx.protocol) {
+        std.mem.nativeTo(u16, proto_ip4, .big) => handle_ipv4(ctx),
+        std.mem.nativeTo(u16, proto_ip6, .big) => handle_ipv6(ctx),
+        else => {},
+    }
+
+    return @intFromEnum(Tc.RET.ok);
+}
+
+fn handle_ipv4(ctx: *Tc.SkBuff) void {
+    const iphdr_offset = @sizeOf(EthHdr);
+    const hdr: *const IPv4Hdr = ctx.get_ptr(IPv4Hdr, iphdr_offset) orelse return;
+    const fmt = "Got IPv4 packet: proto: %d, tot_len: %d, ttl: %d";
+    _ = helpers.trace_printk(fmt, fmt.len + 1, hdr.proto, hdr.tot_len, hdr.ttl);
+
+    const IPPROTO_ICMP = 1;
+    if (hdr.proto == IPPROTO_ICMP) {
+        const payload: *const u32 = ctx.get_ptr(u32, iphdr_offset + @sizeOf(IPv4Hdr) + @sizeOf(IcmpEchoHdr)) orelse return;
+
+        ipv4.update(.any, 0, std.mem.toNative(u32, payload.*, .big));
+    }
+}
+
+fn handle_ipv6(ctx: *Tc.SkBuff) void {
+    const iphdr_offset = @sizeOf(EthHdr);
+    const hdr: *const IPv6Hdr = ctx.get_ptr(IPv6Hdr, iphdr_offset) orelse return;
+    const fmt = "Got IPv6 packet: nxt: %d, plen: %d, hlim: %d";
+    _ = helpers.trace_printk(fmt, fmt.len + 1, hdr.nxt, hdr.plen, hdr.hlim);
+
+    const IPPROTO_ICMPV6 = 58;
+    if (hdr.nxt == IPPROTO_ICMPV6) {
+        const payload: *const u32 = ctx.get_ptr(u32, iphdr_offset + @sizeOf(IPv6Hdr) + @sizeOf(IcmpEchoHdr)) orelse return;
+
+        ipv6.update(.any, 0, std.mem.toNative(u32, payload.*, .big));
+    }
+}

--- a/src/bpf/root.zig
+++ b/src/bpf/root.zig
@@ -1,27 +1,29 @@
-/// Represent [tracepoints](https://docs.kernel.org/trace/tracepoints.html) in kernel.
-pub const Tracepoint = @import("tracepoint.zig");
-/// Represent all kinds of maps in BPF.
-pub const Map = @import("map.zig");
-/// Represent [BPF Iterator](https://docs.kernel.org/bpf/bpf_iterators.html) in bpf program.
-pub const Iterator = @import("iter.zig");
-/// Represent [fentry/fexit](https://docs.kernel.org/trace/fprobe.html) in bpf program.
-pub const Fentry = @import("fentry.zig");
-/// Represent [kprobe/kretprobe](https://docs.kernel.org/trace/kprobes.html?highlight=kprobe) in bpf program.
-pub const Kprobe = @import("kprobe.zig");
-/// Represent syscall in bpf program.
-pub const Ksyscall = @import("ksyscall.zig");
-/// Argument retriever according to different context.
-pub const Args = @import("args.zig");
-/// Represent XDP in bpf program.
-pub const Xdp = @import("xdp.zig");
-/// Represent Uprobe in bpf program.
-pub const Uprobe = @import("uprobe.zig");
-
 const std = @import("std");
 const trace_printk = std.os.linux.BPF.kern.helpers.trace_printk;
 const builtin = std.builtin;
 const SourceLocation = builtin.SourceLocation;
 const StackTrace = builtin.StackTrace;
+
+/// Argument retriever according to different context.
+pub const Args = @import("args.zig");
+/// Represent [fentry/fexit](https://docs.kernel.org/trace/fprobe.html) in bpf program.
+pub const Fentry = @import("fentry.zig");
+/// Represent [BPF Iterator](https://docs.kernel.org/bpf/bpf_iterators.html) in bpf program.
+pub const Iterator = @import("iter.zig");
+/// Represent [kprobe/kretprobe](https://docs.kernel.org/trace/kprobes.html?highlight=kprobe) in bpf program.
+pub const Kprobe = @import("kprobe.zig");
+/// Represent syscall in bpf program.
+pub const Ksyscall = @import("ksyscall.zig");
+/// Represent all kinds of maps in BPF.
+pub const Map = @import("map.zig");
+/// Represent TC in bpf program.
+pub const Tc = @import("tc.zig");
+/// Represent [tracepoints](https://docs.kernel.org/trace/tracepoints.html) in kernel.
+pub const Tracepoint = @import("tracepoint.zig");
+/// Represent Uprobe in bpf program.
+pub const Uprobe = @import("uprobe.zig");
+/// Represent XDP in bpf program.
+pub const Xdp = @import("xdp.zig");
 
 pub inline fn printErr(comptime src: SourceLocation, ret: anytype) void {
     const fmt = "error occur at %s:%d return %d";

--- a/src/bpf/tc.zig
+++ b/src/bpf/tc.zig
@@ -1,0 +1,62 @@
+pub const SkBuff = extern struct {
+    len: u32,
+    pkt_type: u32,
+    mark: u32,
+    queue_mapping: u32,
+    protocol: u32,
+    vlan_present: u32,
+    vlan_tci: u32,
+    vlan_proto: u32,
+    priority: u32,
+    ingress_ifindex: u32,
+    ifindex: u32,
+    tc_index: u32,
+    cb: [5]u32,
+    hash: u32,
+    tc_classid: u32,
+    data: u32,
+    data_end: u32,
+    napi_id: u32,
+    family: u32,
+    remote_ip4: u32,
+    local_ip4: u32,
+    remote_ip6: [4]u32,
+    local_ip6: [4]u32,
+    remote_port: u32,
+    local_port: u32,
+    data_meta: u32,
+    flow_keys: ?*void,
+    tstamp: u64,
+    wire_len: u32,
+    gso_segs: u32,
+    sk: ?*void,
+    gso_size: u32,
+    tstamp_type: u8,
+    hwtstamp: u64,
+
+    /// Get the pointer to the specified offset in the packet with type casting.
+    /// If the offset beyonds the end of the packet, return `null`.
+    pub fn get_ptr(self: *SkBuff, comptime T: type, offset: usize) ?*T {
+        const ptr: usize = self.data + offset;
+
+        if (ptr + @sizeOf(T) > self.data_end) return null;
+
+        return @ptrFromInt(ptr);
+    }
+};
+
+// TC action which the BPF program returns.
+pub const RET = enum(c_int) {
+    /// The default action should be taken.
+    unspec = -1,
+    /// Packet should be proceed.
+    ok = 0,
+    /// The packet has to re-start classification from the root qdisc.
+    reclassify = 1,
+    /// The packet should be dropped, no other TC processing should happen.
+    shot = 2,
+    /// Iterates to the next action, if available.
+    pipe = 3,
+    /// The packet should be redirected, the details of how and where to are set as side effects by helpers functions.
+    redirect = 7,
+};

--- a/src/tests/root.zig
+++ b/src/tests/root.zig
@@ -1,12 +1,13 @@
 const std = @import("std");
 pub const allocator = std.testing.allocator;
+
+const build_options = @import("@build_options");
+
 pub const libbpf = @cImport({
     @cInclude("libbpf.h");
     @cInclude("bpf.h");
     @cInclude("btf.h");
 });
-const build_options = @import("@build_options");
-
 pub fn dbg_printf(level: libbpf.libbpf_print_level, fmt: [*c]const u8, args: @typeInfo(@typeInfo(@typeInfo(libbpf.libbpf_print_fn_t).optional.child).pointer.child).@"fn".params[2].type.?) callconv(.C) c_int {
     if (!build_options.debug and level == libbpf.LIBBPF_DEBUG) return 0;
 
@@ -63,6 +64,7 @@ test {
     _ = @import("kmulprobe.zig");
     _ = @import("ksyscall.zig");
     _ = @import("xdp_ping.zig");
+    _ = @import("tc_ingress.zig");
     _ = @import("kfunc.zig");
     _ = @import("stacktrace.zig");
     _ = @import("uprobe.zig");


### PR DESCRIPTION
This adds support for tc bpf programs.

## References
https://patchwork.kernel.org/project/netdevbpf/patch/20210512103451.989420-3-memxor@gmail.com/
https://github.com/libbpf/libbpf/blob/324f3c3846d99c8a1e1384a55591f893f0ae5de4/src/libbpf.h#L1282
https://github.com/libbpf/libbpf-rs/blob/c6c7e577e9d2c8d7002468093813c3346421d9e3/libbpf-rs/src/tc.rs#L221
https://docs.ebpf.io/linux/program-type/BPF_PROG_TYPE_SCHED_CLS/


